### PR TITLE
update last page as soon as no more data available

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,7 +64,8 @@ const Home = ({ pokemons }: { pokemons: IPokemon[] }) => {
   // when there is no more data limit the page count
   useEffect(() => {
     setLoading(false);
-    pokemonsToShow.length === 0 && setLastPage(currentPage - 1);
+    pokemonsToShow.length === 0 ? setLastPage(currentPage - 1) :
+      pokemonsToShow.length < 20 && setLastPage(currentPage)
   }, [pokemonsToShow])
 
   const d = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
The last page is updated even before receiving no results page. 
i.e: Even if the current page has less than 20 cards (which is a default card count per page), set the last page as the current page.
