### PR TITLE
stop loading only when pokemonsToshow is updated

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,8 +72,12 @@ const Home = ({ pokemons }: { pokemons: IPokemon[] }) => {
       setPokemonsToShow(slicedPokemons)
       updateLastPage(slicedPokemons.length)
     }
-    setLoading(false);
   }, [currentPage, allPokemons])
+
+  // stop loading when new pokemons to show is updated
+  useEffect(() => {
+    setLoading(false)
+  }, [pokemonsToShow])
 
   return (
     <>


### PR DESCRIPTION
The loading concept changed. 
- i.e: the loading is made stopped only when the pokemonsToShow state is updated with the new values fetched.
- new useEffect introduced with pokemonsToShow in the dependency array.
- this new useEffect with make the loading to false once the pokemonsToShow state is changed