### PR TITLE
fixed overflow hidden problem

### DIFF
--- a/components/Popup.tsx
+++ b/components/Popup.tsx
@@ -23,8 +23,10 @@ const Popup = (props: IPopupProps) => {
     useEffect(() => {
         if (props.isPopupOpen)
             window.document.body.style.overflow = "hidden";
-        else if (window.document.body.style.overflow !== null)
+
+        return(()=>{
             window.document.body.style.removeProperty('overflow');
+        })
     }, [props.isPopupOpen])
 
 


### PR DESCRIPTION
issue: after opening the popup and clicking the browser back button makes the page nonscrollable.
status: fixed
solution: removed overflow attribute on component dismount in the popup component